### PR TITLE
Hotfix for #35 Log error and continue when deleting oldest message fails.

### DIFF
--- a/smtpd/filestore.go
+++ b/smtpd/filestore.go
@@ -318,7 +318,7 @@ func (mb *FileMailbox) NewMessage() (Message, error) {
 		for len(mb.messages) >= mb.store.messageCap {
 			log.Infof("Mailbox %q over configured message cap", mb.name)
 			if err := mb.messages[0].Delete(); err != nil {
-				return nil, err
+				log.Errorf("Error deleting message: %s", err)
 			}
 		}
 	}


### PR DESCRIPTION
Hi @jhillyerd 
I've made a hotfix for issue #35.

Regards,
Tomasz