### PR TITLE
Opportunistic TLS Support

### DIFF
--- a/doc/config.md
+++ b/doc/config.md
@@ -22,8 +22,8 @@ variables it supports:
     INBUCKET_SMTP_DISCARDDOMAINS                            Domains to discard mail for
     INBUCKET_SMTP_TIMEOUT               300s                Idle network timeout
     INBUCKET_SMTP_TLSENABLED            false               Enable STARTTLS option
-    INBUCKET_SMTP_TLSPRIVKEY            cert.key            X509 Private Key for TLS Support
-    INBUCKET_SMTP_TLSCERT               cert.crt            X509 Public Certificate for TLS Support
+    INBUCKET_SMTP_TLSPRIVKEY            cert.key            X509 Private Key file for TLS Support
+    INBUCKET_SMTP_TLSCERT               cert.crt            X509 Public Certificate file for TLS Support
     INBUCKET_POP3_ADDR                  0.0.0.0:1100        POP3 server IP4 host:port
     INBUCKET_POP3_DOMAIN                inbucket            HELLO domain
     INBUCKET_POP3_TIMEOUT               600s                Idle network timeout

--- a/doc/config.md
+++ b/doc/config.md
@@ -21,6 +21,9 @@ variables it supports:
     INBUCKET_SMTP_STOREDOMAINS                              Domains to store mail for
     INBUCKET_SMTP_DISCARDDOMAINS                            Domains to discard mail for
     INBUCKET_SMTP_TIMEOUT               300s                Idle network timeout
+    INBUCKET_SMTP_TLSENABLED            false               Enable STARTTLS option
+    INBUCKET_SMTP_TLSPRIVKEY            cert.key            X509 Private Key for TLS Support
+    INBUCKET_SMTP_TLSCERT               cert.crt            X509 Public Certificate for TLS Support
     INBUCKET_POP3_ADDR                  0.0.0.0:1100        POP3 server IP4 host:port
     INBUCKET_POP3_DOMAIN                inbucket            HELLO domain
     INBUCKET_POP3_TIMEOUT               600s                Idle network timeout
@@ -202,6 +205,36 @@ to the public internet.
 - Default: `300s`
 - Values: Duration ending in `s` for seconds, `m` for minutes
 
+### TLS Support Availability
+
+`INBUCKET_SMTP_TLSENABLED`
+
+Enable the STARTTLS option for opportunistic TLS support
+
+- Default: `false`
+- Values: `true` or `false`
+
+### TLS Private Key File
+
+`INBUCKET_SMTP_TLSPRIVKEY`
+
+Specify the x509 Private key file to be used for TLS negotiation.
+This option is only valid when INBUCKET_SMTP_TLSENABLED is enabled.
+
+- Default: `cert.key`
+- Values: filename or path to private key
+- Example: `server.privkey`
+
+### TLS Public Certificate File
+
+`INBUCKET_SMTP_TLSPRIVKEY`
+
+Specify the x509 Certificate file to be used for TLS negotiation.
+This option is only valid when INBUCKET_SMTP_TLSENABLED is enabled.
+
+- Default: `cert.crt`
+- Values: filename or path to the certificate key
+- Example: `server.crt`
 
 ## POP3
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -76,6 +76,9 @@ type SMTP struct {
 	StoreDomains    []string      `desc:"Domains to store mail for"`
 	DiscardDomains  []string      `desc:"Domains to discard mail for"`
 	Timeout         time.Duration `required:"true" default:"300s" desc:"Idle network timeout"`
+	TLSEnabled	bool          `default:"false" desc:"Enable STARTTLS option"`
+	TLSPrivKey	string        `default:"cert.key" desc:"X509 Private Key for TLS Support"`
+	TLSCert		string        `default:"cert.crt" desc:"X509 Public Certificate for TLS Support"`
 	Debug           bool          `ignored:"true"`
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -76,9 +76,9 @@ type SMTP struct {
 	StoreDomains    []string      `desc:"Domains to store mail for"`
 	DiscardDomains  []string      `desc:"Domains to discard mail for"`
 	Timeout         time.Duration `required:"true" default:"300s" desc:"Idle network timeout"`
-	TLSEnabled	bool          `default:"false" desc:"Enable STARTTLS option"`
-	TLSPrivKey	string        `default:"cert.key" desc:"X509 Private Key for TLS Support"`
-	TLSCert		string        `default:"cert.crt" desc:"X509 Public Certificate for TLS Support"`
+	TLSEnabled      bool          `default:"false" desc:"Enable STARTTLS option"`
+	TLSPrivKey      string        `default:"cert.key" desc:"X509 Private Key for TLS Support"`
+	TLSCert         string        `default:"cert.crt" desc:"X509 Public Certificate for TLS Support"`
 	Debug           bool          `ignored:"true"`
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -77,8 +77,8 @@ type SMTP struct {
 	DiscardDomains  []string      `desc:"Domains to discard mail for"`
 	Timeout         time.Duration `required:"true" default:"300s" desc:"Idle network timeout"`
 	TLSEnabled      bool          `default:"false" desc:"Enable STARTTLS option"`
-	TLSPrivKey      string        `default:"cert.key" desc:"X509 Private Key for TLS Support"`
-	TLSCert         string        `default:"cert.crt" desc:"X509 Public Certificate for TLS Support"`
+	TLSPrivKey      string        `default:"cert.key" desc:"X509 Private Key file for TLS Support"`
+	TLSCert         string        `default:"cert.crt" desc:"X509 Public Certificate file for TLS Support"`
 	Debug           bool          `ignored:"true"`
 }
 

--- a/pkg/server/smtp/handler.go
+++ b/pkg/server/smtp/handler.go
@@ -240,7 +240,7 @@ func (s *Server) startSession(id int, conn net.Conn) {
 
 // GREET state -> waiting for HELO
 func (s *Session) greetHandler(cmd string, arg string) {
-	const readyBanner = "250-Great, let's get this show on the road"
+	const readyBanner = "Great, let's get this show on the road"
 	switch cmd {
 	case "HELO":
 		domain, err := parseHelloArgument(arg)
@@ -249,7 +249,7 @@ func (s *Session) greetHandler(cmd string, arg string) {
 			return
 		}
 		s.remoteDomain = domain
-		s.send(readyBanner)
+		s.send("250 " + readyBanner)
 		s.enterState(READY)
 	case "EHLO":
 		domain, err := parseHelloArgument(arg)
@@ -259,7 +259,8 @@ func (s *Session) greetHandler(cmd string, arg string) {
 		}
 		s.remoteDomain = domain
 		// send all options at once so we can deal with aggressive clients
-		respOpts := []string{readyBanner,
+		respOpts := []string{
+			"250-" + readyBanner,
 			"250-8BITMIME",
 		}
 		if s.Server.config.TLSEnabled && s.Server.TLSconfig != nil && s.tlsState == nil {
@@ -517,7 +518,7 @@ func (s *Session) parseCmd(line string) (cmd string, arg string, ok bool) {
 		return strings.ToUpper(line), "", true
 	case l == 5:
 		// Too long to be only command, too short to have args
-		s.logger.Warn().Msgf("too long - no args Mangled command: %q", line)
+		s.logger.Warn().Msgf("Mangled command: %q", line)
 		return "", "", false
 	}
 	// If we made it here, command is long enough to have args

--- a/pkg/server/smtp/handler.go
+++ b/pkg/server/smtp/handler.go
@@ -10,6 +10,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"crypto/tls"
+	"net/textproto"
 
 	"github.com/jhillyerd/inbucket/pkg/policy"
 	"github.com/rs/zerolog"
@@ -73,6 +75,7 @@ var commands = map[string]bool{
 	"NOOP": true,
 	"QUIT": true,
 	"TURN": true,
+	"STARTTLS": true,
 }
 
 // Session holds the state of an SMTP session
@@ -89,12 +92,15 @@ type Session struct {
 	recipients   []*policy.Recipient // Recipients from RCPT commands.
 	logger       zerolog.Logger      // Session specific logger.
 	debug        bool                // Print network traffic to stdout.
+	tlsState     *tls.ConnectionState
+	text         *textproto.Conn
 }
 
 // NewSession creates a new Session for the given connection
 func NewSession(server *Server, id int, conn net.Conn, logger zerolog.Logger) *Session {
 	reader := bufio.NewReader(conn)
 	host, _, _ := net.SplitHostPort(conn.RemoteAddr().String())
+
 	return &Session{
 		Server:     server,
 		id:         id,
@@ -105,6 +111,7 @@ func NewSession(server *Server, id int, conn net.Conn, logger zerolog.Logger) *S
 		recipients: make([]*policy.Recipient, 0),
 		logger:     logger,
 		debug:      server.config.Debug,
+		text:       textproto.NewConn(conn),
 	}
 }
 
@@ -135,6 +142,7 @@ func (s *Server) startSession(id int, conn net.Conn) {
 	}()
 
 	ssn := NewSession(s, id, conn, logger)
+	defer ssn.text.Close()
 	ssn.greet()
 
 	// This is our command reading loop
@@ -232,6 +240,7 @@ func (s *Server) startSession(id int, conn net.Conn) {
 
 // GREET state -> waiting for HELO
 func (s *Session) greetHandler(cmd string, arg string) {
+	const readyBanner = "250-Great, let's get this show on the road"
 	switch cmd {
 	case "HELO":
 		domain, err := parseHelloArgument(arg)
@@ -240,7 +249,7 @@ func (s *Session) greetHandler(cmd string, arg string) {
 			return
 		}
 		s.remoteDomain = domain
-		s.send("250 Great, let's get this show on the road")
+		s.send(readyBanner)
 		s.enterState(READY)
 	case "EHLO":
 		domain, err := parseHelloArgument(arg)
@@ -249,9 +258,16 @@ func (s *Session) greetHandler(cmd string, arg string) {
 			return
 		}
 		s.remoteDomain = domain
-		s.send("250-Great, let's get this show on the road")
-		s.send("250-8BITMIME")
-		s.send(fmt.Sprintf("250 SIZE %v", s.config.MaxMessageBytes))
+		// send all options at once so we can deal with aggressive clients
+		respOpts := []string { readyBanner,
+				       "250-8BITMIME",
+				     }
+		if s.Server.config.TLSEnabled && s.Server.TLSconfig != nil && s.tlsState == nil {
+			respOpts = append(respOpts, "250-STARTTLS")
+		}
+		// features before SIZE per RFC
+		respOpts = append(respOpts, fmt.Sprintf("250 SIZE %v", s.config.MaxMessageBytes))
+		s.send(strings.Join(respOpts[:], "\n"))
 		s.enterState(READY)
 	default:
 		s.ooSeq(cmd)
@@ -271,7 +287,29 @@ func parseHelloArgument(arg string) (string, error) {
 
 // READY state -> waiting for MAIL
 func (s *Session) readyHandler(cmd string, arg string) {
-	if cmd == "MAIL" {
+	if cmd == "STARTTLS" {
+		if !s.Server.config.TLSEnabled {
+			// invalid command since unconfigured
+			s.logger.Debug().Msgf("454 TLS unavailable on the server")
+			s.send("454 TLS unavailable on the server")
+			return
+		}
+		if s.tlsState != nil {
+			// tls state previously valid
+			s.logger.Debug().Msg("454 A TLS session already agreed upon.")
+			s.send("454 A TLS session already agreed upon.")
+			return
+		}
+		s.logger.Debug().Msg("Initiating TLS context.")
+		s.send("220 STARTTLS")
+		// start tls connection handshake
+		tlsConn := tls.Server(s.conn, s.Server.TLSconfig)
+		s.conn = tlsConn
+		s.text = textproto.NewConn(s.conn)
+		s.tlsState = new (tls.ConnectionState)
+		*s.tlsState = tlsConn.ConnectionState()
+		s.enterState(GREET)
+	} else if cmd == "MAIL" {
 		// Capture group 1: from address.  2: optional params.
 		m := fromRegex.FindStringSubmatch(arg)
 		if m == nil {
@@ -367,57 +405,43 @@ func (s *Session) mailHandler(cmd string, arg string) {
 // DATA
 func (s *Session) dataHandler() {
 	s.send("354 Start mail input; end with <CRLF>.<CRLF>")
-	msgBuf := &bytes.Buffer{}
-	for {
-		lineBuf, err := s.readByteLine()
-		if err != nil {
-			if netErr, ok := err.(net.Error); ok {
-				if netErr.Timeout() {
-					s.send("221 Idle timeout, bye bye")
-				}
+	msgBuf, err := s.readByteLine()
+	if err != nil {
+		if netErr, ok := err.(net.Error); ok {
+			if netErr.Timeout() {
+				s.send("221 Idle timeout, bye bye")
 			}
-			s.logger.Warn().Msgf("Error: %v while reading", err)
-			s.enterState(QUIT)
-			return
 		}
-		if bytes.Equal(lineBuf, []byte(".\r\n")) || bytes.Equal(lineBuf, []byte(".\n")) {
-			// Mail data complete.
-			tstamp := time.Now().Format(timeStampFormat)
-			for _, recip := range s.recipients {
-				if recip.ShouldStore() {
-					// Generate Received header.
-					prefix := fmt.Sprintf("Received: from %s ([%s]) by %s\r\n  for <%s>; %s\r\n",
-						s.remoteDomain, s.remoteHost, s.config.Domain, recip.Address.Address,
-						tstamp)
-					// Deliver message.
-					_, err := s.manager.Deliver(
-						recip, s.from, s.recipients, prefix, msgBuf.Bytes())
-					if err != nil {
-						s.logger.Error().Msgf("delivery for %v: %v", recip.LocalPart, err)
-						s.send(fmt.Sprintf("451 Failed to store message for %v", recip.LocalPart))
-						s.reset()
-						return
-					}
-				}
-				expReceivedTotal.Add(1)
-			}
-			s.send("250 Mail accepted for delivery")
-			s.logger.Info().Msgf("Message size %v bytes", msgBuf.Len())
-			s.reset()
-			return
-		}
-		// RFC: remove leading periods from DATA.
-		if len(lineBuf) > 0 && lineBuf[0] == '.' {
-			lineBuf = lineBuf[1:]
-		}
-		msgBuf.Write(lineBuf)
-		if msgBuf.Len() > s.config.MaxMessageBytes {
-			s.send("552 Maximum message size exceeded")
-			s.logger.Warn().Msgf("Max message size exceeded while in DATA")
-			s.reset()
-			return
-		}
+		s.logger.Warn().Msgf("Error: %v while reading", err)
+		s.enterState(QUIT)
+		return
 	}
+	mailData := bytes.NewBuffer(msgBuf)
+
+	// Mail data complete.
+	tstamp := time.Now().Format(timeStampFormat)
+	for _, recip := range s.recipients {
+		if recip.ShouldStore() {
+			// Generate Received header.
+			prefix := fmt.Sprintf("Received: from %s ([%s]) by %s\r\n  for <%s>; %s\r\n",
+				s.remoteDomain, s.remoteHost, s.config.Domain, recip.Address.Address,
+				tstamp)
+			// Deliver message.
+			_, err := s.manager.Deliver(
+				recip, s.from, s.recipients, prefix, mailData.Bytes())
+			if err != nil {
+				s.logger.Error().Msgf("delivery for %v: %v", recip.LocalPart, err)
+				s.send(fmt.Sprintf("451 Failed to store message for %v", recip.LocalPart))
+				s.reset()
+				return
+			}
+		}
+		expReceivedTotal.Add(1)
+	}
+	s.send("250 Mail accepted for delivery")
+	s.logger.Info().Msgf("Message size %v bytes", mailData.Len())
+	s.reset()
+	return
 }
 
 func (s *Session) enterState(state State) {
@@ -440,7 +464,7 @@ func (s *Session) send(msg string) {
 		s.sendError = err
 		return
 	}
-	if _, err := fmt.Fprint(s.conn, msg+"\r\n"); err != nil {
+	if err :=s.text.PrintfLine("%s", msg); err != nil {
 		s.sendError = err
 		s.logger.Warn().Msgf("Failed to send: %q", msg)
 		return
@@ -455,9 +479,12 @@ func (s *Session) readByteLine() ([]byte, error) {
 	if err := s.conn.SetReadDeadline(s.nextDeadline()); err != nil {
 		return nil, err
 	}
-	b, err := s.reader.ReadBytes('\n')
-	if err == nil && s.debug {
-		fmt.Printf("%04d   %s\n", s.id, bytes.TrimRight(b, "\r\n"))
+	b, err := s.text.ReadDotBytes()
+	if err != nil {
+		return nil, err
+	}
+	if s.debug {
+		s.logger.Debug().Msgf("%s", b)
 	}
 	return b, err
 }
@@ -467,7 +494,7 @@ func (s *Session) readLine() (line string, err error) {
 	if err = s.conn.SetReadDeadline(s.nextDeadline()); err != nil {
 		return "", err
 	}
-	line, err = s.reader.ReadString('\n')
+	line, err = s.text.ReadLine()
 	if err != nil {
 		return "", err
 	}
@@ -486,11 +513,11 @@ func (s *Session) parseCmd(line string) (cmd string, arg string, ok bool) {
 	case l < 4:
 		s.logger.Warn().Msgf("Command too short: %q", line)
 		return "", "", false
-	case l == 4:
+	case l == 4 || l == 8:
 		return strings.ToUpper(line), "", true
 	case l == 5:
 		// Too long to be only command, too short to have args
-		s.logger.Warn().Msgf("Mangled command: %q", line)
+		s.logger.Warn().Msgf("too long - no args Mangled command: %q", line)
 		return "", "", false
 	}
 	// If we made it here, command is long enough to have args

--- a/pkg/server/smtp/handler.go
+++ b/pkg/server/smtp/handler.go
@@ -258,17 +258,13 @@ func (s *Session) greetHandler(cmd string, arg string) {
 			return
 		}
 		s.remoteDomain = domain
-		// send all options at once so we can deal with aggressive clients
-		respOpts := []string{
-			"250-" + readyBanner,
-			"250-8BITMIME",
-		}
-		if s.Server.config.TLSEnabled && s.Server.TLSconfig != nil && s.tlsState == nil {
-			respOpts = append(respOpts, "250-STARTTLS")
-		}
 		// features before SIZE per RFC
-		respOpts = append(respOpts, fmt.Sprintf("250 SIZE %v", s.config.MaxMessageBytes))
-		s.send(strings.Join(respOpts[:], "\n"))
+                s.send("250-" + readyBanner)
+                s.send("250-8BITMIME")
+                if s.Server.config.TLSEnabled && s.Server.TLSconfig != nil && s.tlsState == nil {
+                        s.send("250-STARTTLS")
+                }
+                s.send(fmt.Sprintf("250 SIZE %v", s.config.MaxMessageBytes))
 		s.enterState(READY)
 	default:
 		s.ooSeq(cmd)

--- a/pkg/server/smtp/handler.go
+++ b/pkg/server/smtp/handler.go
@@ -259,12 +259,12 @@ func (s *Session) greetHandler(cmd string, arg string) {
 		}
 		s.remoteDomain = domain
 		// features before SIZE per RFC
-                s.send("250-" + readyBanner)
-                s.send("250-8BITMIME")
-                if s.Server.config.TLSEnabled && s.Server.TLSconfig != nil && s.tlsState == nil {
-                        s.send("250-STARTTLS")
-                }
-                s.send(fmt.Sprintf("250 SIZE %v", s.config.MaxMessageBytes))
+		s.send("250-" + readyBanner)
+		s.send("250-8BITMIME")
+		if s.Server.config.TLSEnabled && s.Server.tlsConfig != nil && s.tlsState == nil {
+			s.send("250-STARTTLS")
+		}
+		s.send(fmt.Sprintf("250 SIZE %v", s.config.MaxMessageBytes))
 		s.enterState(READY)
 	default:
 		s.ooSeq(cmd)
@@ -300,7 +300,7 @@ func (s *Session) readyHandler(cmd string, arg string) {
 		s.logger.Debug().Msg("Initiating TLS context.")
 		s.send("220 STARTTLS")
 		// start tls connection handshake
-		tlsConn := tls.Server(s.conn, s.Server.TLSconfig)
+		tlsConn := tls.Server(s.conn, s.Server.tlsConfig)
 		s.conn = tlsConn
 		s.text = textproto.NewConn(s.conn)
 		s.tlsState = new(tls.ConnectionState)
@@ -481,7 +481,7 @@ func (s *Session) readByteLine() ([]byte, error) {
 		return nil, err
 	}
 	if s.debug {
-		s.logger.Debug().Msgf("%s", b)
+		fmt.Printf("%04d   Received %d bytes\n", s.id, len(b))
 	}
 	return b, err
 }

--- a/pkg/server/smtp/handler.go
+++ b/pkg/server/smtp/handler.go
@@ -3,15 +3,15 @@ package smtp
 import (
 	"bufio"
 	"bytes"
+	"crypto/tls"
 	"fmt"
 	"io"
 	"net"
+	"net/textproto"
 	"regexp"
 	"strconv"
 	"strings"
 	"time"
-	"crypto/tls"
-	"net/textproto"
 
 	"github.com/jhillyerd/inbucket/pkg/policy"
 	"github.com/rs/zerolog"
@@ -60,21 +60,21 @@ func (s State) String() string {
 }
 
 var commands = map[string]bool{
-	"HELO": true,
-	"EHLO": true,
-	"MAIL": true,
-	"RCPT": true,
-	"DATA": true,
-	"RSET": true,
-	"SEND": true,
-	"SOML": true,
-	"SAML": true,
-	"VRFY": true,
-	"EXPN": true,
-	"HELP": true,
-	"NOOP": true,
-	"QUIT": true,
-	"TURN": true,
+	"HELO":     true,
+	"EHLO":     true,
+	"MAIL":     true,
+	"RCPT":     true,
+	"DATA":     true,
+	"RSET":     true,
+	"SEND":     true,
+	"SOML":     true,
+	"SAML":     true,
+	"VRFY":     true,
+	"EXPN":     true,
+	"HELP":     true,
+	"NOOP":     true,
+	"QUIT":     true,
+	"TURN":     true,
 	"STARTTLS": true,
 }
 
@@ -259,9 +259,9 @@ func (s *Session) greetHandler(cmd string, arg string) {
 		}
 		s.remoteDomain = domain
 		// send all options at once so we can deal with aggressive clients
-		respOpts := []string { readyBanner,
-				       "250-8BITMIME",
-				     }
+		respOpts := []string{readyBanner,
+			"250-8BITMIME",
+		}
 		if s.Server.config.TLSEnabled && s.Server.TLSconfig != nil && s.tlsState == nil {
 			respOpts = append(respOpts, "250-STARTTLS")
 		}
@@ -306,7 +306,7 @@ func (s *Session) readyHandler(cmd string, arg string) {
 		tlsConn := tls.Server(s.conn, s.Server.TLSconfig)
 		s.conn = tlsConn
 		s.text = textproto.NewConn(s.conn)
-		s.tlsState = new (tls.ConnectionState)
+		s.tlsState = new(tls.ConnectionState)
 		*s.tlsState = tlsConn.ConnectionState()
 		s.enterState(GREET)
 	} else if cmd == "MAIL" {
@@ -464,7 +464,7 @@ func (s *Session) send(msg string) {
 		s.sendError = err
 		return
 	}
-	if err :=s.text.PrintfLine("%s", msg); err != nil {
+	if err := s.text.PrintfLine("%s", msg); err != nil {
 		s.sendError = err
 		s.logger.Warn().Msgf("Failed to send: %q", msg)
 		return

--- a/pkg/server/smtp/listener.go
+++ b/pkg/server/smtp/listener.go
@@ -64,7 +64,7 @@ type Server struct {
 	manager        message.Manager    // Used to deliver messages.
 	listener       net.Listener       // Incoming network connections.
 	wg             *sync.WaitGroup    // Waitgroup tracks individual sessions.
-	TLSconfig      *tls.Config
+	tlsConfig      *tls.Config
 }
 
 // NewServer creates a new Server instance with the specificed config.
@@ -74,16 +74,18 @@ func NewServer(
 	manager message.Manager,
 	apolicy *policy.Addressing,
 ) *Server {
-
+	slog := log.With().Str("module", "smtp").Str("phase", "tls").Logger()
 	tlsConfig := &tls.Config{}
 	if smtpConfig.TLSEnabled {
 		var err error
 		tlsConfig.Certificates = make([]tls.Certificate, 1)
 		tlsConfig.Certificates[0], err = tls.LoadX509KeyPair(smtpConfig.TLSCert, smtpConfig.TLSPrivKey)
 		if err != nil {
-			log.Error().Msgf("Failed loading X509 KeyPair: %v", err)
-			log.Error().Msgf("Disabling STARTTLS support")
+			slog.Error().Msgf("Failed loading X509 KeyPair: %v", err)
+			slog.Error().Msg("Disabling STARTTLS support")
 			smtpConfig.TLSEnabled = false
+		} else {
+			slog.Debug().Msg("STARTTLS feature available")
 		}
 	}
 
@@ -93,7 +95,7 @@ func NewServer(
 		manager:        manager,
 		addrPolicy:     apolicy,
 		wg:             new(sync.WaitGroup),
-		TLSconfig:      tlsConfig,
+		tlsConfig:      tlsConfig,
 	}
 }
 

--- a/pkg/server/smtp/listener.go
+++ b/pkg/server/smtp/listener.go
@@ -2,8 +2,8 @@ package smtp
 
 import (
 	"container/list"
-	"crypto/tls"
 	"context"
+	"crypto/tls"
 	"expvar"
 	"net"
 	"sync"
@@ -93,7 +93,7 @@ func NewServer(
 		manager:        manager,
 		addrPolicy:     apolicy,
 		wg:             new(sync.WaitGroup),
-		TLSconfig:	tlsConfig,
+		TLSconfig:      tlsConfig,
 	}
 }
 


### PR DESCRIPTION
# Feature added to support the STARTTLS option.
This adds support for opportunistic TLS connections for SMTP-only. Clients that follow the RFC of:
```
  S: 220 inbucket Inbucket SMTP ready
  C: EHLO openssl.client.net
  S: 250-Great, let's get this show on the road
  S: 250-8BITMIME
  S: 250-STARTTLS
  S: 250 SIZE 10240000
  C: STARTTLS
  S: 220 STARTTLS
  C: <starts TLS negotiation>
  C & S: <negotiate a TLS session>
  C & S: <check result of negotiation>
  C: EHLO nowhere.tld
  . . .
```
This feature is **disabled** by default.

## Setup
To generate x509 certs:
```bash
$ openssl req -x509 -sha256 -newkey rsa:2048 -keyout certificate.key -out certificate.crt -days 1024 -nodes
```
Run inbucket with TLS Enabled (the default private key is **cert.key** and default public key is **cert.crt**) -- you can change these with environmental variable also:
```bash
$ INBUCKET_SMTP_TLSENABLED=true ./inbucket 
```
To use openssl's s_client for testing:
```bash
$ cat << EOF | openssl s_client -tls1_2 -starttls smtp -crlf -connect 127.0.0.1:2500 -ign_eof
ehlo nowhere.tld
mail from: <me@me.me>
rcpt to: <you@you.you>
data
Subject: Hello

This is the body

.
QUIT
EOF
```
